### PR TITLE
Fix CompareType for SKU and PartNumber properties

### DIFF
--- a/OCPServerHardwareManagement.v0_2_4.json
+++ b/OCPServerHardwareManagement.v0_2_4.json
@@ -71,7 +71,7 @@
 					"ConditionalRequirements": [{
 						"Purpose": "Either PartNumber or SKU (or both) must be implemented.",
 						"CompareProperty": "PartNumber",
-						"Comparison": "Absent",
+						"CompareType": "Absent",
 						"ReadRequirement": "Mandatory"
 					}]
 				},
@@ -80,7 +80,7 @@
 					"ConditionalRequirements": [{
 						"Purpose": "Either PartNumber or SKU (or both) must be implemented.",
 						"CompareProperty": "SKU",
-						"Comparison": "Absent",
+						"CompareType": "Absent",
 						"ReadRequirement": "Mandatory"
 					}]
 				},


### PR DESCRIPTION
OCP server hardware management requires either ComputerSystem.SKU
or ComputerSystem.PartNumber (or both) to be implemented. This can
be achieved by setting ReadRequirement field to Recommended, and using
ConditionalRequirements to change this field to Mandatory if SKU or
PartNumber does not exist.

According to Redfish Interoperability Profiles (DSP0272 v1.2.0),
section 8.4.2.5 defines:
+ Comparison: The condition used to compare the value of the property
to "Values".
+ CompareType: The condition used to compare the value of the property
named by "CompareProperty" to the value of "CompareValues". If the
comparison is true, this conditional requirement applies.

This patch changes Comparison to CompareType for SKU and PartNumber.
So, SKU ReadRequirement is Mandatory if PartNumber (CompareProperty)
is Absent (CompareType) and vice versa.

Signed-off-by: Hieu Vu <hieutrgvu@gmail.com>