### PR TITLE
Fix typos in MinNeededInGroup

### DIFF
--- a/HWMgmt/OCPBaselineHardwareManagement.v1_1_0.json
+++ b/HWMgmt/OCPBaselineHardwareManagement.v1_1_0.json
@@ -435,7 +435,7 @@
 					"ReadRequirement": "IfImplemented",
 					"PropertyRequirements": {
 						"RedundancyType": {},
-						"MinNeededinGroup": {},
+						"MinNeededInGroup": {},
 						"MaxSupportedInGroup": {
 							"ReadRequirement": "Recommended"
 						},

--- a/OCPBaselineHardwareManagement.v1_1_0.json
+++ b/OCPBaselineHardwareManagement.v1_1_0.json
@@ -435,7 +435,7 @@
 					"ReadRequirement": "IfImplemented",
 					"PropertyRequirements": {
 						"RedundancyType": {},
-						"MinNeededinGroup": {},
+						"MinNeededInGroup": {},
 						"MaxSupportedInGroup": {
 							"ReadRequirement": "Recommended"
 						},


### PR DESCRIPTION
MinNeededinGroup -> MinNeededInGroup

This will cause correct implementations to fail the profile validator.

Signed-off-by: Ed Tanous <etanous@nvidia.com>
