### PR TITLE
Added Ambient ReadRequirement

### DIFF
--- a/RackAndPower/OCPPowerShelf.v1_0_0.json
+++ b/RackAndPower/OCPPowerShelf.v1_0_0.json
@@ -133,7 +133,9 @@
                 "TemperatureReadingsCelsius": {},
                 "TemperatureSummaryCelsius": {
                     "PropertyRequirements": {
-                        "Ambient": {},
+                        "Ambient": {
+                            "ReadRequirement": "IfImplemented"
+                        },
                         "Internal": {}
                     }
                 }


### PR DESCRIPTION
Assumed not all hardwares have sensor for Ambient reading. If property does not exist, report shall not return an error.